### PR TITLE
linux: Update desktop file to follow spec guidelines

### DIFF
--- a/linux_pkg/bulwark-passkey/usr/share/applications/id.bulwark.BulwarkPasskey.desktop
+++ b/linux_pkg/bulwark-passkey/usr/share/applications/id.bulwark.BulwarkPasskey.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Version=1.1
 Name=Bulwark Passkey
 Comment=Virtual FIDO Device
 Exec=bulwark_passkey


### PR DESCRIPTION
The desktop-file-spec recommends following reverse-dns style naming conventions.

https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html